### PR TITLE
strong mode fix

### DIFF
--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -8,8 +8,8 @@ import 'ast.dart';
 import 'document.dart';
 import 'util.dart';
 
-///Maps an URL (specified in a reference).
-///If nothing to change, just return [url].
+/// Maps an URL (specified in a reference).
+/// If nothing to change, just return [url].
 typedef String LinkMapper(InlineParser parser, String url);
 
 /// Maintains the internal state needed to parse inline span elements in
@@ -367,7 +367,8 @@ class LinkSyntax extends TagSyntax {
       }
 
       url = _map(parser, url);
-      if (url == null || url is Link) return url;
+      if (url == null) return null;
+      if (url is Link) return url as Link;
       assert(url is! Node); //not allowed here
 
       return new Link(null, url, title);


### PR DESCRIPTION
Fix an issue where the DDC thought a `String` was being returned as a `Link`:

```
The return type 'String' is not a 'Link', as defined by the method 'getLink' (package:markd/src/inline_parser.dart, line 370, col 46)
Type check failed: url (String) is not of type Link (package:markd/src/inline_parser.dart, line 370, col 46)
```
