### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/tool/update_blns.dart
+++ b/tool/update_blns.dart
@@ -12,7 +12,7 @@ Future<Null> main() async {
   try {
     var request = await client.getUrl(Uri.parse(_blnsJsonRawUrl));
     var response = await request.close();
-    json = (jsonDecode(await response.transform(utf8.decoder).join('')) as List)
+    json = (jsonDecode(await utf8.decoder.bind(response).join('')) as List)
         .cast<String>();
   } finally {
     client.close();

--- a/tool/update_emojis.dart
+++ b/tool/update_emojis.dart
@@ -10,7 +10,7 @@ Future<Null> main() async {
   var client = new HttpClient();
   var request = await client.getUrl(Uri.parse(_emojisJsonRawUrl));
   var response = await request.close();
-  var json = jsonDecode(await response.transform(utf8.decoder).join(''))
+  var json = jsonDecode(await utf8.decoder.bind(response).join(''))
       .map((alias, info) => new MapEntry(alias, info.cast<String, dynamic>()))
       .cast<String, Map<String, dynamic>>();
   var emojisContent = new StringBuffer('''


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
